### PR TITLE
Make installation instructions simpler to use

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,27 @@
+Package: user2018skoval
+Title: Material from 2018 UseR Conference: Statistical Models for Sport in R
+Version: 1.0.0
+Author: Stephanie Kovalchik
+Depends:
+  rvest,
+  jsonlite,
+  dplyr,
+  tidyr,
+  stringr,
+  ggplot2,
+  ggthemes,
+  scales,
+  lubridate,
+  BradleyTerry2,
+  pitchRx,
+  mgcv,
+  rjags,
+  deuce,
+  RSelenium,
+  wdman,
+  binman
+Remotes:
+  skoval/deuce,
+  ropensci/RSelenium,
+  johndharrison/wdman,
+  johndharrison/binman

--- a/README.md
+++ b/README.md
@@ -2,29 +2,31 @@
 
 The repo includes R markdown files and html slides for the tutorial.
 
-For attendees of the workshop, completing all of the examples will require that you have installed all of the following packages from CRAN:
+For attendees of the workshop, install all required packages with the following
 
-- rvest
-- jsonlite
-- dplyr
-- tidyr
-- stringr
-- ggplot2
-- ggthemes
-- scales
-- lubridate
-- BradleyTerry2
-- pitchRx
-- mgcv
-- rjags
+```r
+devtools::install_github('skoval/UseR2018')
+```
 
-Install the following package from github:
+Or alternatively manually install the following packages from CRAN:
 
-- deuce with `install_github('skoval/deuce')`
+```r
+install.packages(c(
+  'rvest', 'jsonlite', 'dplyr', 'tidyr', 'stringr', 'ggplot2', 'ggthemes',
+  'scales', 'lubridate', 'BradleyTerry2', 'pitchRx', 'mgcv', 'rjags'))
+```
 
-- RSelenium with `install_github('ropensci/Rselenium')`
+And the following packages from GitHub
 
-Install the following additional software:
+```r
+devtools::install_github(c(
+  'skoval/deuce',
+  'johndharrison/wdman',
+  'johndharrison/binman',
+  'ropensci/Rselenium'
+  ))
+```
+
+Also install the following additional software:
 
 - Docker @ https://docs.docker.com/install/
-


### PR DESCRIPTION
Create a stub package so all installation can be done with one line, or
give the exact commands needed otherwise.

wdman and binman are RSelenium dependencies, which are also not
available on CRAN.

This should help make things easier for people trying to get prepared for the tutorial, looking forward to it!